### PR TITLE
Bring the web dashboard's prober to engine parity with the Mac app

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -139,7 +139,7 @@ fi
 GATEWAY_SRC="$ROOT/gateway"
 if [[ -d "$GATEWAY_SRC" ]]; then
   mkdir -p "$APP/Contents/Resources/gateway"
-  for f in server.py nodes.py dashboard.html config.example.json start.sh README.md; do
+  for f in server.py nodes.py engines.py dashboard.html config.example.json start.sh README.md; do
     [[ -f "$GATEWAY_SRC/$f" ]] && cp "$GATEWAY_SRC/$f" "$APP/Contents/Resources/gateway/"
   done
   chmod +x "$APP/Contents/Resources/gateway/start.sh" 2>/dev/null || true

--- a/gateway/engines.py
+++ b/gateway/engines.py
@@ -1,0 +1,147 @@
+"""Inference-engine knowledge for the web dashboard's node prober.
+
+Python twin of the Swift app's InferenceEngine + ProbeParsers
+(Sources/Honeycomb/Services/ProbeParsers.swift) so the browser dashboard
+sees the same fleet the Mac app does. Keep the two in sync: match tokens,
+default ports, and metric names live here and there. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, NamedTuple
+
+
+class Engine(NamedTuple):
+    name: str          # raw id, matches Swift rawValue ("vllm", "sglang", "llama.cpp")
+    label: str         # display name
+    match_tokens: tuple[str, ...]  # substrings marking a container image/command
+    default_port: int  # port bound when launched without --port
+    kv_metric: str     # 0-1 usage ratio gauge on /metrics
+    running_metric: str
+    gen_metric: str
+
+
+# Order is detection priority — a vLLM serve of a llama model must match
+# vllm, not llama.cpp.
+ENGINES: tuple[Engine, ...] = (
+    Engine("sglang", "SGLang", ("sglang",), 30000,
+           "sglang:token_usage",
+           "sglang:num_running_reqs",
+           "sglang:generation_tokens_total"),
+    Engine("vllm", "vLLM", ("vllm",), 8000,
+           "vllm:kv_cache_usage_perc",
+           "vllm:num_requests_running",
+           "vllm:generation_tokens_total"),
+    Engine("llama.cpp", "llama.cpp", ("llama",), 8080,
+           "llamacpp:kv_cache_usage_ratio",
+           "llamacpp:requests_processing",
+           "llamacpp:tokens_predicted_total"),
+)
+
+ALL_MATCH_TOKENS: tuple[str, ...] = tuple(
+    t for e in ENGINES for t in e.match_tokens
+)
+
+_PORT_FLAG = re.compile(r"--port[=\"',\\ \t]+([0-9]{1,5})")
+
+
+def detect(text: str) -> Engine | None:
+    lowered = text.lower()
+    for engine in ENGINES:
+        if any(token in lowered for token in engine.match_tokens):
+            return engine
+    return None
+
+
+def serve_from_docker_inspect(text: str) -> tuple[Engine | None, int | None]:
+    """Engine + API port from `docker inspect --format
+    '{{json .Config.Entrypoint}} {{json .Config.Cmd}}'` output.
+
+    Handles both arg-array form ("--port","8888") and a bash -lc wrapper
+    where the flag lives inside one escaped string. An explicit --port wins;
+    otherwise the recognized engine's default. (None, None) when no known
+    serve command is visible — callers keep the configured baseURL then.
+    """
+    engine = detect(text)
+    m = _PORT_FLAG.search(text)
+    if m:
+        port = int(m.group(1))
+        if 1 <= port <= 65535:
+            return engine, port
+    return engine, engine.default_port if engine else None
+
+
+def metrics_from_prometheus(text: str) -> dict[str, Any]:
+    """The handful of engine gauges the map cares about — all three engines'
+    names are tried; the sets are disjoint. Keys match the /nodes payload."""
+    def value(metrics: list[str]) -> float | None:
+        for line in text.splitlines():
+            for metric in metrics:
+                if line.startswith(metric):
+                    try:
+                        return float(line.rsplit(" ", 1)[1])
+                    except (ValueError, IndexError):
+                        return None
+        return None
+
+    out: dict[str, Any] = {}
+    kv = value([e.kv_metric for e in ENGINES])
+    if kv is not None:
+        out["kvCachePct"] = kv * 100
+    running = value([e.running_metric for e in ENGINES])
+    if running is not None:
+        out["runningRequests"] = int(running)
+    gen = value([e.gen_metric for e in ENGINES])
+    if gen is not None:
+        out["genTokensTotal"] = gen
+    return out
+
+
+def running_inference_containers(
+    docker_ps: str, preferred: str | None = None
+) -> list[str]:
+    """Names of running inference containers from `docker ps` Names\\tImage
+    lines. Host-network serves publish no ports, so match the image against
+    the engine tokens, plus the fleet preferred name when it is running."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in docker_ps.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", 1)
+        name = parts[0].strip()
+        if not name or name in seen:
+            continue
+        image = (parts[1] if len(parts) > 1 else "").lower()
+        is_inference = any(token in image for token in ALL_MATCH_TOKENS)
+        if is_inference or (preferred is not None and name == preferred):
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def models_from_json(raw: bytes | str) -> list[str]:
+    """Model ids from a models-listing response: OpenAI /v1/models
+    (data[].id), LM Studio (models[].id), or Ollama /api/tags
+    (models[].name / models[].model)."""
+    try:
+        data = json.loads(raw if isinstance(raw, str) else raw.decode())
+    except Exception:
+        return []
+    if not isinstance(data, dict):
+        return []
+    for key in ("data", "models"):
+        items = data.get(key)
+        if isinstance(items, list):
+            ids = [
+                m.get("id") or m.get("name") or m.get("model")
+                for m in items
+                if isinstance(m, dict)
+            ]
+            ids = [i for i in ids if i]
+            if ids:
+                return ids
+    return []

--- a/gateway/nodes.py
+++ b/gateway/nodes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import threading
@@ -16,6 +17,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import engines
 
 FLEET_PATH = Path(
     os.environ.get(
@@ -88,59 +92,80 @@ def _http_models(base_url: str, models_path: str) -> tuple[bool, list[str], floa
         with urllib.request.urlopen(url, timeout=3.0) as resp:
             raw = resp.read()
         ms = (time.perf_counter() - t0) * 1000
-        data = json.loads(raw.decode() or "{}")
-        models = [m.get("id") for m in data.get("data", []) if m.get("id")]
-        return True, models, ms
+        return True, engines.models_from_json(raw), ms
     except Exception:
         return False, [], None
 
 
-def _ssh_metrics(host: str) -> dict[str, Any] | None:
+_DOCKER_MARKER = "==HONEYCOMB-DOCKER=="
+
+
+def _ssh_host_probe(
+    host: str, preferred: str | None
+) -> tuple[bool, dict[str, Any] | None, engines.Engine | None, int | None]:
+    """One SSH spawn, same as the Mac app: GPU util + memory, plus the engine
+    and API port of whatever inference container is actually running. Serves
+    can move ports and swap engines between restarts; the configured baseURL
+    is only a fallback when nothing can be discovered.
+    Returns (ssh_ok, metrics, engine, port)."""
+    tokens = "|".join(engines.ALL_MATCH_TOKENS)
     cmd = (
         "free -m | awk '/^Mem:/{print $3, $2}'; "
-        "nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits"
+        "nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits; "
+        f"echo {_DOCKER_MARKER}; "
+        "docker ps --format '{{.Names}} {{.Image}}'"
+        f" | awk -v pref={shlex.quote(preferred or '')}"
+        f" 'tolower($0) ~ /{tokens}/ || (pref != \"\" && $1 == pref) {{print $1}}'"
+        " | head -n 3"
+        " | xargs -r docker inspect --format"
+        " '{{json .Config.Entrypoint}} {{json .Config.Cmd}}' 2>/dev/null"
+        " || true"
     )
     code, out = _run(["ssh", *SSH_OPTS, "--", host, cmd], timeout=7)
     if code != 0:
-        return None
-    lines = [l.strip() for l in out.splitlines() if l.strip()]
+        return False, None, None, None
+    parts = out.split(_DOCKER_MARKER)
+    lines = [l.strip() for l in parts[0].splitlines() if l.strip()]
     metrics: dict[str, Any] = {}
     if lines:
-        parts = lines[0].split()
-        if len(parts) == 2 and all(p.isdigit() for p in parts):
-            metrics["memUsedMB"] = int(parts[0])
-            metrics["memTotalMB"] = int(parts[1])
+        mem = lines[0].split()
+        if len(mem) == 2 and all(p.isdigit() for p in mem):
+            metrics["memUsedMB"] = int(mem[0])
+            metrics["memTotalMB"] = int(mem[1])
     if len(lines) > 1 and lines[1].lstrip("-").isdigit():
         metrics["gpuUtilPct"] = int(lines[1])
-    return metrics or None
+    engine, port = (
+        engines.serve_from_docker_inspect(parts[1]) if len(parts) > 1 else (None, None)
+    )
+    return True, metrics or None, engine, port
 
 
-def _vllm_metrics(base_url: str) -> dict[str, Any]:
+def _with_port(base_url: str, port: int | None) -> str:
+    """base_url with the discovered API port applied (host unchanged)."""
+    if not port:
+        return base_url
+    try:
+        parts = urlsplit(base_url)
+        host = parts.hostname or ""
+        if ":" in host:  # bare IPv6 needs brackets back
+            host = f"[{host}]"
+        return urlunsplit(
+            (parts.scheme, f"{host}:{port}", parts.path, parts.query, parts.fragment)
+        )
+    except Exception:
+        return base_url
+
+
+def _engine_metrics(base_url: str) -> dict[str, Any]:
+    """Engine Prometheus gauges (vLLM, SGLang, or llama.cpp /metrics)."""
     import urllib.request
 
-    out: dict[str, Any] = {}
     try:
         with urllib.request.urlopen(base_url.rstrip("/") + "/metrics", timeout=3.0) as resp:
             text = resp.read().decode()
     except Exception:
-        return out
-
-    def value(metric: str) -> float | None:
-        for line in text.splitlines():
-            if line.startswith(metric):
-                try:
-                    return float(line.rsplit(" ", 1)[1])
-                except Exception:
-                    return None
-        return None
-
-    kv = value("vllm:kv_cache_usage_perc")
-    if kv is not None:
-        out["kvCachePct"] = kv * 100
-    gen = value("vllm:generation_tokens_total")
-    if gen is not None:
-        out["genTokensTotal"] = gen
-    return out
+        return {}
+    return engines.metrics_from_prometheus(text)
 
 
 # node_id -> (timestamp, generation_tokens_total) for tok/s deltas
@@ -149,18 +174,21 @@ _gen_history: dict[str, tuple[float, float]] = {}
 
 def _probe_vllm_ssh(node: dict[str, Any]) -> dict[str, Any]:
     host = node.get("sshHost")
-    ssh_ok = False
-    if host:
-        code, _ = _run(["ssh", *SSH_OPTS, "--", host, "echo", "ok"], timeout=6)
-        ssh_ok = code == 0
-    infer_ok, models, latency = _http_models(node["baseURL"], node.get("modelsPath", "/v1/models"))
+    ssh_ok, metrics, engine, port = (
+        _ssh_host_probe(host, node.get("container") or None)
+        if host
+        else (False, None, None, None)
+    )
+    # Inference is checked wherever the running serve actually listens —
+    # the configured baseURL is only the fallback when discovery is empty.
+    base = _with_port(node["baseURL"], port)
+    infer_ok, models, latency = _http_models(base, node.get("modelsPath", "/v1/models"))
 
-    metrics = _ssh_metrics(host) if (host and ssh_ok) else None
     if infer_ok:
-        vm = _vllm_metrics(node["baseURL"])
-        if vm:
-            metrics = {**(metrics or {}), **vm}
-            gen = vm.get("genTokensTotal")
+        em = _engine_metrics(base)
+        if em:
+            metrics = {**(metrics or {}), **em}
+            gen = em.get("genTokensTotal")
             if gen is not None:
                 now = time.time()
                 with _lock:  # probes run concurrently in a thread pool
@@ -169,15 +197,17 @@ def _probe_vllm_ssh(node: dict[str, Any]) -> dict[str, Any]:
                 if prev and gen >= prev[1] and now - prev[0] > 0.5:
                     metrics["genTokPerSec"] = (gen - prev[1]) / (now - prev[0])
 
+    ename = engine.name if engine else "vllm"
     health = "online" if ssh_ok else ("online" if infer_ok else "offline")
     parts = []
     if ssh_ok:
         parts.append("ssh")
     if infer_ok:
-        parts.append("vllm · " + (models[0].split("/")[-1][:24] if models else "idle"))
+        parts.append(f"{ename} · " + (models[0].split("/")[-1][:24] if models else "idle"))
     else:
         parts.append("inference idle")
-    badge = "SSH+vLLM" if (ssh_ok and infer_ok) else ("SSH" if ssh_ok else ("API" if infer_ok else "DOWN"))
+    label = engine.label if engine else "vLLM"
+    badge = f"SSH+{label}" if (ssh_ok and infer_ok) else ("SSH" if ssh_ok else ("API" if infer_ok else "DOWN"))
     return {
         "health": health,
         "models": models,
@@ -467,36 +497,12 @@ def action_doctor(node_id: str) -> dict[str, Any]:
     return {"ok": report["error"] is None, **report}
 
 
-def _running_inference_containers(docker_ps: str, preferred: str | None) -> list[str]:
-    """Names of running inference containers from `docker ps` Names\\tImage lines.
-
-    Host-network vLLM publishes no ports, so match image containing 'vllm',
-    plus the fleet preferred name when that container is running.
-    """
-    names: list[str] = []
-    seen: set[str] = set()
-    for line in docker_ps.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        parts = line.split("\t", 1)
-        name = parts[0].strip()
-        if not name or name in seen:
-            continue
-        image = (parts[1] if len(parts) > 1 else "").lower()
-        is_vllm = "vllm" in image
-        is_preferred = preferred is not None and name == preferred
-        if is_vllm or is_preferred:
-            seen.add(name)
-            names.append(name)
-    return names
-
-
 def action_container(node_id: str, verb: str) -> dict[str, Any]:
     """docker start/stop over SSH.
 
     start — fleet.json container name only.
-    stop  — whatever vLLM container is actually running (not a stale preferred name).
+    stop  — whatever inference container (vLLM, SGLang, llama.cpp) is
+    actually running, not a stale preferred name.
     """
     if verb not in ("start", "stop"):
         return {"ok": False, "error": "verb must be start or stop"}
@@ -538,7 +544,7 @@ def action_container(node_id: str, verb: str) -> dict[str, Any]:
     if code != 0:
         return {"ok": False, "error": f"docker ps failed (exit {code}) {out.strip()[:120]}"}
 
-    targets = _running_inference_containers(out, preferred)
+    targets = engines.running_inference_containers(out, preferred)
     if not targets and preferred:
         targets = [preferred]
     if not targets:

--- a/gateway/tests/test_engines.py
+++ b/gateway/tests/test_engines.py
@@ -1,0 +1,201 @@
+"""Tests for gateway/engines.py — same fixtures as the Swift side
+(Tests/HoneycombTests/ProbeParsersTests.swift) so both frontends parse
+the fleet identically. Run: python3 -m unittest discover gateway/tests
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import engines  # noqa: E402
+
+
+class MetricsFromPrometheus(unittest.TestCase):
+    def test_vllm(self):
+        prom = (
+            "# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.\n"
+            "# TYPE vllm:kv_cache_usage_perc gauge\n"
+            'vllm:kv_cache_usage_perc{model_name="qwen2.5-7b"} 0.42\n'
+            'vllm:num_requests_running{model_name="qwen2.5-7b"} 3.0\n'
+            'vllm:generation_tokens_total{model_name="qwen2.5-7b"} 123456.0\n'
+        )
+        m = engines.metrics_from_prometheus(prom)
+        self.assertAlmostEqual(m["kvCachePct"], 42.0)
+        self.assertEqual(m["runningRequests"], 3)
+        self.assertAlmostEqual(m["genTokensTotal"], 123456.0)
+
+    def test_sglang(self):
+        prom = (
+            'sglang:token_usage{model_name="qwen3-32b"} 0.17\n'
+            'sglang:num_running_reqs{model_name="qwen3-32b"} 2.0\n'
+            'sglang:cache_hit_rate{model_name="qwen3-32b"} 0.61\n'
+            'sglang:generation_tokens_total{model_name="qwen3-32b"} 98765.0\n'
+        )
+        m = engines.metrics_from_prometheus(prom)
+        self.assertAlmostEqual(m["kvCachePct"], 17.0)
+        self.assertEqual(m["runningRequests"], 2)
+        self.assertAlmostEqual(m["genTokensTotal"], 98765.0)
+
+    def test_llamacpp(self):
+        prom = (
+            "llamacpp:kv_cache_usage_ratio 0.25\n"
+            "llamacpp:requests_processing 1\n"
+            "llamacpp:tokens_predicted_total 4242\n"
+        )
+        m = engines.metrics_from_prometheus(prom)
+        self.assertAlmostEqual(m["kvCachePct"], 25.0)
+        self.assertEqual(m["runningRequests"], 1)
+        self.assertAlmostEqual(m["genTokensTotal"], 4242.0)
+
+    def test_missing_gauges(self):
+        self.assertEqual(engines.metrics_from_prometheus("# nothing here\n"), {})
+
+
+class RunningInferenceContainers(unittest.TestCase):
+    mixed = (
+        "agents-a1-nvfp4\tnvcr.io/nvidia/vllm:26.06-py3\n"
+        "minimax-model-nfs\tgists/nfs-server:latest\n"
+        "hermes-firecrawl-api\tghcr.io/firecrawl/firecrawl:latest\n"
+        "hermes-searxng\tsearxng/searxng:latest\n"
+    )
+
+    def test_picks_vllm_only(self):
+        self.assertEqual(
+            engines.running_inference_containers(self.mixed), ["agents-a1-nvfp4"]
+        )
+
+    def test_includes_preferred_non_vllm(self):
+        self.assertEqual(
+            engines.running_inference_containers(self.mixed, "hermes-searxng"),
+            ["agents-a1-nvfp4", "hermes-searxng"],
+        )
+
+    def test_preferred_not_running_ignored(self):
+        self.assertEqual(
+            engines.running_inference_containers(self.mixed, "nemotron-puzzle-75b"),
+            ["agents-a1-nvfp4"],
+        )
+
+    def test_empty(self):
+        self.assertEqual(engines.running_inference_containers(""), [])
+
+    def test_case_insensitive_image(self):
+        self.assertEqual(
+            engines.running_inference_containers("qwen\tNVCR.IO/NVIDIA/VLLM:latest\n"),
+            ["qwen"],
+        )
+
+    def test_matches_sglang_and_llama_images(self):
+        text = (
+            "sg1\tlmsysorg/sglang:latest\n"
+            "cpp1\tghcr.io/ggml-org/llama.cpp:server\n"
+            "redis\tredis:7\n"
+        )
+        self.assertEqual(
+            engines.running_inference_containers(text), ["sg1", "cpp1"]
+        )
+
+
+class ServeFromDockerInspect(unittest.TestCase):
+    def test_port_from_arg_array_cmd(self):
+        text = 'null ["vllm","serve","deepseek-ai/DeepSeek-V4","--port","8888","--host","0.0.0.0"]'
+        engine, port = engines.serve_from_docker_inspect(text)
+        self.assertEqual(engine.name, "vllm")
+        self.assertEqual(port, 8888)
+
+    def test_port_inside_bash_wrapper_string(self):
+        text = (
+            'null ["bash","-lc","export PATH=...; exec /usr/local/bin/vllm serve'
+            ' deepseek-ai/DeepSeek-V4-Flash-DSpark --port 8888 --tensor-parallel-size 2"]'
+        )
+        engine, port = engines.serve_from_docker_inspect(text)
+        self.assertEqual(engine.name, "vllm")
+        self.assertEqual(port, 8888)
+
+    def test_port_equals_form(self):
+        text = '["vllm","serve"] ["m","--port=9010"]'
+        self.assertEqual(engines.serve_from_docker_inspect(text)[1], 9010)
+
+    def test_vllm_defaults_to_8000(self):
+        engine, port = engines.serve_from_docker_inspect(
+            'null ["vllm","serve","meta-llama/Llama-3.3-70B"]'
+        )
+        self.assertEqual(engine.name, "vllm")
+        self.assertEqual(port, 8000)
+
+    def test_sglang_explicit_port(self):
+        text = 'null ["python3","-m","sglang.launch_server","--model-path","Qwen/Qwen3-32B","--port","30001","--tp","2"]'
+        engine, port = engines.serve_from_docker_inspect(text)
+        self.assertEqual(engine.name, "sglang")
+        self.assertEqual(port, 30001)
+
+    def test_sglang_defaults_to_30000(self):
+        text = 'null ["bash","-lc","python3 -m sglang.launch_server --model-path Qwen/Qwen3-32B"]'
+        engine, port = engines.serve_from_docker_inspect(text)
+        self.assertEqual(engine.name, "sglang")
+        self.assertEqual(port, 30000)
+
+    def test_llamacpp_explicit_port(self):
+        text = '["/app/llama-server"] ["-m","/models/qwen.gguf","--port","9000","-ngl","99"]'
+        engine, port = engines.serve_from_docker_inspect(text)
+        self.assertEqual(engine.name, "llama.cpp")
+        self.assertEqual(port, 9000)
+
+    def test_llamacpp_defaults_to_8080(self):
+        engine, port = engines.serve_from_docker_inspect(
+            '["/app/llama-server"] ["-m","/models/qwen.gguf"]'
+        )
+        self.assertEqual(engine.name, "llama.cpp")
+        self.assertEqual(port, 8080)
+
+    def test_none_when_no_known_engine(self):
+        self.assertEqual(engines.serve_from_docker_inspect(""), (None, None))
+        self.assertEqual(
+            engines.serve_from_docker_inspect('null ["redis-server"]'), (None, None)
+        )
+
+    def test_ignores_garbage_port_values(self):
+        # out-of-range port falls back to the engine default, not None
+        text = 'null ["vllm","serve","m","--port","999999"]'
+        self.assertEqual(engines.serve_from_docker_inspect(text)[1], 8000)
+
+    def test_detection_priority_vllm_over_llama(self):
+        # a vLLM serve of a llama model must match vllm, not llama.cpp
+        engine, _ = engines.serve_from_docker_inspect(
+            'null ["vllm","serve","meta-llama/Llama-3.3-70B"]'
+        )
+        self.assertEqual(engine.name, "vllm")
+
+
+class ModelsFromJSON(unittest.TestCase):
+    def test_openai_list(self):
+        raw = '{"object":"list","data":[{"id":"qwen2.5-7b"},{"id":"llama-3.2-3b"}]}'
+        self.assertEqual(engines.models_from_json(raw), ["qwen2.5-7b", "llama-3.2-3b"])
+
+    def test_lmstudio_shape(self):
+        self.assertEqual(
+            engines.models_from_json('{"models":[{"id":"mistral-nemo-12b"}]}'),
+            ["mistral-nemo-12b"],
+        )
+
+    def test_ollama_tags(self):
+        raw = '{"models":[{"name":"llama3:8b"},{"model":"phi3:mini"}]}'
+        self.assertEqual(engines.models_from_json(raw), ["llama3:8b", "phi3:mini"])
+
+    def test_empty_list(self):
+        self.assertEqual(engines.models_from_json('{"object":"list","data":[]}'), [])
+
+    def test_garbage(self):
+        self.assertEqual(engines.models_from_json("not json"), [])
+        self.assertEqual(engines.models_from_json(b"not json"), [])
+
+    def test_bytes_input(self):
+        self.assertEqual(
+            engines.models_from_json(b'{"data":[{"id":"m1"}]}'), ["m1"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

The browser dashboard — the only Honeycomb frontend on Windows/iPad — still assumed every GPU node runs vLLM on its configured port. The Swift app had already learned SGLang/llama.cpp support (recent commits: serve discovery, port auto-discovery, /metrics gauges). This ports that engine knowledge to the gateway:

- **New `gateway/engines.py`** — stdlib-only Python twin of the Swift `InferenceEngine` + `ProbeParsers`: engine detection with the same priority order (a vLLM serve of a Llama model matches vLLM, not llama.cpp), default API ports, per-engine Prometheus metric names, `docker inspect` port extraction, inference-container matching, and models-JSON parsing that now also handles LM Studio and Ollama response shapes.
- **`gateway/nodes.py`** — the `vllm-ssh` probe now makes one consolidated SSH call (mirroring the app) that fetches memory/GPU metrics plus the engine and actual `--port` of whatever inference container is running. Inference is checked at the discovered port; the configured `baseURL` is only the fallback. Status detail and badge report the real engine (`sglang · qwen3-32b`, `SSH+SGLang`) instead of always claiming vLLM, and `/metrics` parsing adds `runningRequests`. STOP now discovers any inference container, not just vLLM ones.
- **`gateway/tests/test_engines.py`** — 27 unittest cases using the exact fixtures from `ProbeParsersTests.swift`, pinning the two implementations to identical behavior. Run: `python3 -m unittest discover gateway/tests`.
- **`Scripts/package_app.sh`** — the bundled gateway now ships `engines.py`.

## Why

Keeps the deliberate app/dashboard duplication (per CLAUDE.md) actually in sync, and halves per-node SSH round-trips in the gateway prober the same way the Swift side did.

## Verification

- Swift suite 36/36, new Python tests 27/27.
- Booted the gateway with a scratch config; `/health` and `/nodes` serve correctly through the new import chain.
- Ran the new probe against both live Spark boxes: online, correct hardware metrics, and correctly reported no inference engine (cross-checked `docker ps` — nothing serving at the time). The one path not verified live is engine/port discovery with a serve actually running; its parsers are fixture-tested against real command lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)